### PR TITLE
Fix numbering to start from 1 or add numbering where necessary

### DIFF
--- a/koans/week_2_lesson_3_about_true_and_false.py
+++ b/koans/week_2_lesson_3_about_true_and_false.py
@@ -24,7 +24,7 @@ class AboutTrueAndFalse(Koan):
         self.assertEquals(__, dessert);
 
     # 3
-    def test_false_is_false(self):
+    def test_false_number_is_false(self):
         dessert = "chocolate"
 
         if 0:

--- a/koans/week_3_lesson_1_about_file_IO.py
+++ b/koans/week_3_lesson_1_about_file_IO.py
@@ -3,14 +3,14 @@ from runner.koan import *
 
 class AboutFileIO(Koan):
 
-    #2
+    #1
     def test_reading_full_file(self):
         the_file = open("one_line.txt")
         contents = the_file.read()
 
         self.assertEqual(__, contents)
 
-    #3
+    #2
     def test_reading_file_with_multiple_lines(self):
         the_file = open("short_lines.txt")
 
@@ -19,7 +19,7 @@ class AboutFileIO(Koan):
 
         self.assertEqual(__, contents)
 
-    #4
+    #3
     def test_reading_lines_directly(self):
         the_file = open("short_lines.txt")
 
@@ -27,7 +27,7 @@ class AboutFileIO(Koan):
 
         self.assertEqual(__, lines)
 
-    #5
+    #4
     def test_reading_file_line_by_line(self):
         the_file = open("short_lines.txt")
 
@@ -40,7 +40,7 @@ class AboutFileIO(Koan):
         one_more = the_file.readline()
         self.assertEqual(__, one_more)
 
-    #6
+    #5
     def test_reading_file_with_for(self):
         the_file = open("short_lines.txt")
 
@@ -51,7 +51,7 @@ class AboutFileIO(Koan):
 
         self.assertEqual(__, lines)
 
-    #7
+    #6
     def test_reading_file_with_for_strip(self):
         the_file = open("short_lines.txt")
 
@@ -63,7 +63,7 @@ class AboutFileIO(Koan):
 
         self.assertEqual(__, lines)
 
-    #8
+    #7
     def test_reading_file_with_with(self):
         # there are a number of reasons for it,
         # but using with is the prefered way of opening a file

--- a/koans/week_3_lesson_2_about_exceptions_part1.py
+++ b/koans/week_3_lesson_2_about_exceptions_part1.py
@@ -5,7 +5,7 @@ from runner.koan import *
 
 class AboutExceptions(Koan):
 
-    #2
+    #1
     def test_catch_problems(self):
 
         try:
@@ -15,7 +15,7 @@ class AboutExceptions(Koan):
 
         self.assertEqual(__, result)
 
-    #3
+    #2
     def test_can_return_message(self):
 
         try:
@@ -25,7 +25,7 @@ class AboutExceptions(Koan):
 
         self.assertEqual(__, result)
 
-    #4
+    #3
     def test_types_of_exceptions(self):
 
         try:
@@ -38,7 +38,7 @@ class AboutExceptions(Koan):
 
         self.assertEqual(__, result)
 
-    #5
+    #4
     def test_finally(self):
 
         try:
@@ -50,7 +50,7 @@ class AboutExceptions(Koan):
 
         self.assertEqual(__, result)
 
-    #6
+    #5
     def test_finally_success(self):
 
         try:
@@ -62,7 +62,7 @@ class AboutExceptions(Koan):
 
         self.assertEqual(__, result)
 
-    #7
+    #6
     def test_assert_is_raised(self):
         with self.assertRaises(__):
             result = 12 / 0

--- a/koans/week_3_lesson_3_about_comprehension.py
+++ b/koans/week_3_lesson_3_about_comprehension.py
@@ -6,7 +6,7 @@ from runner.koan import *
 
 class AboutComprehension(Koan):
 
-
+    # 1
     def test_creating_lists_with_list_comprehensions(self):
         feast = ['lambs', 'sloths', 'orangutans', 'breakfast cereals',
             'fruit bats']
@@ -16,6 +16,7 @@ class AboutComprehension(Koan):
         self.assertEqual(__, comprehension[0])
         self.assertEqual(__, comprehension[2])
 
+    # 2
     def test_filtering_lists_with_list_comprehensions(self):
         feast = ['spam', 'sloths', 'orangutans', 'breakfast cereals',
             'fruit bats']
@@ -25,6 +26,7 @@ class AboutComprehension(Koan):
         self.assertEqual(__, len(feast))
         self.assertEqual(__, len(comprehension))
 
+    # 3
     def test_unpacking_tuples_in_list_comprehensions(self):
         list_of_tuples = [(1, 'lumberjack'), (2, 'inquisition'), (4, 'spam')]
         comprehension = [ skit * number for number, skit in list_of_tuples ]
@@ -32,6 +34,7 @@ class AboutComprehension(Koan):
         self.assertEqual(__, comprehension[0])
         self.assertEqual(__, comprehension[2])
 
+    # 4
     def test_double_list_comprehension(self):
         list_of_eggs = ['poached egg', 'fried egg']
         list_of_meats = ['lite spam', 'ham spam', 'fried spam']
@@ -43,11 +46,13 @@ class AboutComprehension(Koan):
         self.assertEqual(__, comprehension[0])
         self.assertEqual(__, len(comprehension))
 
+    # 5
     def test_creating_a_set_with_set_comprehension(self):
         comprehension = { x for x in 'aabbbcccc'}
 
         self.assertEqual(__, comprehension)  # remember that set members are unique
 
+    # 6
     def test_creating_a_dictionary_with_dictionary_comprehension(self):
         dict_of_weapons = {'first': 'fear', 'second': 'surprise',
                            'third':'ruthless efficiency', 'fourth':'fanatical devotion',

--- a/koans/week_3_lesson_5_about_regex.py
+++ b/koans/week_3_lesson_5_about_regex.py
@@ -9,7 +9,7 @@ class AboutRegex(Koan):
         I found this books very useful so I decided to write a koans in order to practice everything I had learned from it.
         http://www.forta.com/books/0672325667/
     """
-
+    # 1
     def test_findall_multiple_times(self):
         being = "Malkovich, Malkovich Malkovich. Malkovich Malkovich Malkovich"
         m = re.findall('Malkovich', being)
@@ -17,13 +17,14 @@ class AboutRegex(Koan):
         self.assertEqual(__, m)
         self.assertEqual(__, len(m))
 
+    # 2
     def test_matching_literal_text_not_case_sensitivity(self):
         movie_007 = "hello my name is bond, james bond. sadly my shift key is broken"
 
         self.assertEqual(re.findall("Bond", movie_007), __)
         self.assertEqual(re.findall("Bond", movie_007, re.IGNORECASE), __)
 
-
+    # 3
     def test_matching_numbers(self):
         address = "Beverly Hills 90210"
         numbers_only_regex = '[0-9]'
@@ -31,6 +32,7 @@ class AboutRegex(Koan):
         numbers_only = re.findall(numbers_only_regex, address)
         self.assertEquals(__,numbers_only)
 
+    # 4
     def test_matching_numbers(self):
         address = "Beverly Hills 90210"
         lower_case_letters_only_regex = '[a-z]'
@@ -38,6 +40,7 @@ class AboutRegex(Koan):
         lower_case_letters_only = re.findall(lower_case_letters_only_regex, address)
         self.assertEquals(__,lower_case_letters_only)
 
+    # 5
     def test_matching_set_character(self):
         boys_names = """
         Harry
@@ -51,6 +54,7 @@ class AboutRegex(Koan):
         names_I_like = re.findall(starts_with_b_or_h_then_arry, boys_names)
         self.assertEquals(__,names_I_like)
 
+    # 6
     def test_matching_set_character(self):
         girls_names = """
         Evangeline
@@ -64,7 +68,7 @@ class AboutRegex(Koan):
         names_I_like = re.findall(ends_with_ine, girls_names,  re.IGNORECASE)
         self.assertEquals(__,names_I_like)
 
-
+    # 7
     def test_matching_anything_but(self):
         girls_names = """
         Evangeline

--- a/koans/week_3_lesson_5_about_regex.py
+++ b/koans/week_3_lesson_5_about_regex.py
@@ -33,7 +33,7 @@ class AboutRegex(Koan):
         self.assertEquals(__,numbers_only)
 
     # 4
-    def test_matching_numbers(self):
+    def test_matching_lower_case(self):
         address = "Beverly Hills 90210"
         lower_case_letters_only_regex = '[a-z]'
 

--- a/koans/week_3_lesson_5_about_regex.py
+++ b/koans/week_3_lesson_5_about_regex.py
@@ -41,7 +41,7 @@ class AboutRegex(Koan):
         self.assertEquals(__,lower_case_letters_only)
 
     # 5
-    def test_matching_set_character(self):
+    def test_matching_set_character_starts_with(self):
         boys_names = """
         Harry
         Perry
@@ -55,7 +55,7 @@ class AboutRegex(Koan):
         self.assertEquals(__,names_I_like)
 
     # 6
-    def test_matching_set_character(self):
+    def test_matching_set_character_ends_with(self):
         girls_names = """
         Evangeline
         Carolynn

--- a/koans/week_4_lesson_1_about_procedure.py
+++ b/koans/week_4_lesson_1_about_procedure.py
@@ -13,7 +13,7 @@ def Adele_one_liner(): print("How you doin?")
 
 class AboutProcedures(Koan):
 
-    #2
+    #1
     def test_calling_a_method(self):
 
         i = 0
@@ -24,7 +24,7 @@ class AboutProcedures(Koan):
         self.assertEqual(__, i)
         # look at the console!
 
-    #3
+    #2
     def test_calling_a_method_with_parameter(self):
 
         i = 0
@@ -35,11 +35,11 @@ class AboutProcedures(Koan):
         self.assertEqual(__, i)
         # look at the console!
 
-    #4
+    #3
     def test_the_documentation_can_be_viewed_with_the_doc_method(self):
         self.assertEqual(__, Adele_says.__doc__)
 
-    #5
+    #4
     def test_calling_method_with_wrong_number_of_arguments_messages(self):
         try:
             Adele_says()
@@ -56,12 +56,12 @@ class AboutProcedures(Koan):
         self.assertEqual(__, msg)
 
 
-    #6
+    #5
     def test_calling_method_with_wrong_number_of_arguments(self):
         with self.assertRaises(__):
             result = Adele_says("hello","and then some")
 
-    #7
+    #6
     def test_calling_a_one_line_method(self):
 
         i = 0

--- a/koans/week_4_lesson_3_about_none.py
+++ b/koans/week_4_lesson_3_about_none.py
@@ -9,16 +9,16 @@ from runner.koan import *
 
 class AboutNone(Koan):
 
-    #2
+    #1
     def test_none_is_an_object(self):
         self.assertEqual(__, type(None))
 
-    #3
+    #2
     def test_none_is_universal(self):
         "There is only one None"
         self.assertEqual(____, None is None)
 
-    #4
+    #3
     def test_none_is_distinct(self):
         """
         None is distinct from other things which are False.

--- a/koans/week_4_lesson_4_about_recursion.py
+++ b/koans/week_4_lesson_4_about_recursion.py
@@ -28,11 +28,11 @@ from runner.koan import *
 
 class AboutRecursion(Koan):
 
-    #2
+    #1
     def test_functions_can_call_each_other(self):
         self.assertEqual(__, multiply_by_adding(5,3))
 
-    #3
+    #2
     def test_functions_can_call_themselves(self):
         self.assertEqual(__, factorial(7))
 

--- a/koans/week_4_lesson_5_about_lambdas.py
+++ b/koans/week_4_lesson_5_about_lambdas.py
@@ -12,9 +12,6 @@ class AboutLambdas(Koan):
         self.assertEqual(__, type(add_one))
         self.assertEqual(__, add_one(10))
 
-
-
-
     #2
     def test_accessing_lambda_via_assignment(self):
 


### PR DESCRIPTION
Comment numbering fixes for week 3. Lesson 4 seemed to be already correctly numbered.

Additionally, in lesson 5 there were two tests with the name `test_matching_numbers` (_3_ and _4_), however this name only seemed to be correct for _3_, _4_ was the test where lowercase letter matching had to be done, hence I've renamed it to `test_matching_lower_case`.

A similar case for tests _5_ and _6_ (still lesson 5). One was about matching a prefix in some set, and the other about matching a suffix, so I've renamed them appropriately to reflect that.