### PR TITLE
Small fix

### DIFF
--- a/koans/week_2_lesson_3_about_true_and_false.py
+++ b/koans/week_2_lesson_3_about_true_and_false.py
@@ -33,7 +33,7 @@ class AboutTrueAndFalse(Koan):
         self.assertEquals(__, dessert);
 
 
-    # 3
+    # 4
     def test_empty_string_is_false(self):
         dessert = "chocolate"
 
@@ -42,7 +42,7 @@ class AboutTrueAndFalse(Koan):
 
         self.assertEquals(__, dessert);
 
-    # 4
+    # 5
     def test_empty_set_is_false(self):
         dessert = "chocolate"
 
@@ -51,7 +51,7 @@ class AboutTrueAndFalse(Koan):
 
         self.assertEquals(__, dessert);
 
-    # 5
+    # 6
     def empty_list_is_false(self):
         dessert = "chocolate"
 
@@ -60,7 +60,7 @@ class AboutTrueAndFalse(Koan):
 
         self.assertEquals(__, dessert);
 
-    # 6
+    # 7
     def test_everything_else_is_treated_as_true(self):
         dessert = "chocolate"
 

--- a/koans/week_4_lesson_1_about_procedure.py
+++ b/koans/week_4_lesson_1_about_procedure.py
@@ -6,7 +6,7 @@ def Adele_says_hello():
     print("Hello from the other side")
 
 def Adele_says(line):
-    "This method prints the inputted line"
+    """This method prints the inputted line"""
     print(line)
 
 def Adele_one_liner(): print("How you doin?")

--- a/koans/week_4_lesson_2_about_functions.py
+++ b/koans/week_4_lesson_2_about_functions.py
@@ -5,7 +5,7 @@ def add(a, b):
     return a + b
 
 def format_info(name, age = 18):
-   "This returns the passed info as a nicely formatted string"
+   """This returns the passed info as a nicely formatted string"""
    name_and_age_formatted = "{0} is currently {1} years old".format(name,age)
 
    return name_and_age_formatted

--- a/koans/week_5_lesson_1_about_classes.py
+++ b/koans/week_5_lesson_1_about_classes.py
@@ -2,7 +2,7 @@ from runner.koan import *
 
 
 class Dog:
-    "Dogs need regular walks. Never, ever let them drive."
+    """Dogs need regular walks. Never, ever let them drive."""
     age = 1
 
     def age_in_dog_years(self):

--- a/koans/week_5_lesson_4_about_class_attributes.py
+++ b/koans/week_5_lesson_4_about_class_attributes.py
@@ -9,7 +9,7 @@ from runner.koan import *
 
 class AboutClassAttributes(Koan):
     class Dog:
-        "I am a dog without a name."
+        """I am a dog without a name."""
         latin_name = "Canine"
 
     def test_classes_have_their_own_attributes_too(self):


### PR DESCRIPTION
numbering fix
docstrings uses triple quotes and to keep it consistent with the rest of the files